### PR TITLE
Sabbat-pattern helmets description edit

### DIFF
--- a/ManifestUpdater/Resources/internal_manifest.json
+++ b/ManifestUpdater/Resources/internal_manifest.json
@@ -30,7 +30,7 @@
         "RepoName": "RT_Adepta_Sororitas_Sabbat_Pattern_Helmets"
       }
     },
-    "About": "This mod adds the familiar Sabbat-pattern helmet employed by the Adepta Sororitas. This is a new model made by me (although a hooded version uses one of Owlcat's hood models)",
+    "About": "Adds several Sabbat-pattern helmets for Argenta (or mod-added Sororitas background RTs) throughout the game.",
     "HomepageUrl": "https://www.nexusmods.com/warhammer40kroguetrader/mods/178",
     "Tags": [ "Visuals" ]
   },


### PR DESCRIPTION
Switched the description for the Sabbat-pattern helmets mod to match the existing short description on Github and Nexus.