### PR TITLE
Add "Additional Character Names" mod to manifest

### DIFF
--- a/ManifestUpdater/Resources/internal_manifest.json
+++ b/ManifestUpdater/Resources/internal_manifest.json
@@ -1,6 +1,23 @@
 [
   // Please keep sorted by Name.
   {
+    "Name": "Additional Character Names",
+    "Author": "DarthParametric",
+    "Id": {
+      "Id": "DPAdditionalCharacterNames",
+      "Type": "Owlcat"
+    },
+    "Service": {
+      "Github": {
+        "Owner": "DarthParametric",
+        "RepoName": "RT_Additional_Character_Names"
+      }
+    "About": "Adds additional random names for the RT and mercenaries in the character creator.",
+    "HomepageUrl": "https://www.nexusmods.com/warhammer40kroguetrader/mods/191",
+    "Tags": [ "Miscellaneous", "UserInterface" ]
+  },
+
+  {
     "Name": "Additional Reactivity",
     "Author": "juliabel",
     "Id": {


### PR DESCRIPTION
Adds a mod that expands the pool of randomly generated player and mercenary names.